### PR TITLE
offer :cancel-fn for dialogs, to handle a cancel via ESC key

### DIFF
--- a/src-dev/re_mdl/demo.cljs
+++ b/src-dev/re_mdl/demo.cljs
@@ -379,7 +379,10 @@
                     [mdl/button
                      :label "CLOSE"
                      :on-click #(reset! open? false)
-                     ]]])])))
+                     ]]
+          :cancel-fn #(do
+                        (.log js/console "Dialog cancelled!")
+                        (reset! open? false))])])))
 
 (defn list-demo []
   [mdl/grid


### PR DESCRIPTION
Fixes #8 

You can now give a `:cancel-fn` key to dialogs to handle a user cancelling them with ESC. Prevents the default behaviour, which is to remove the `open` attribute from the dialog.