### PR TITLE
19 cond thread bug

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -26,7 +26,7 @@
 
   :source-paths ["src/cljc"]
 
-  :clean-targets ^{:protect false} ["resources/public/js/compiled" "target"]
+  :clean-targets ^{:protect false} ["resources/public/js/compiled" "target" "out"]
 
   :aliases {"ci" ["do"
                   ["doo" "phantom" "test" "once"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.yetanalytics/re-mdl "0.1.7"
+(defproject com.yetanalytics/re-mdl "0.1.8-SNAPSHOT"
   :description "Yet another library of reusable UI components for Reagent"
   :url "https://github.com/yetanalytics/re-mdl.git"
   :license {:name "Eclipse Public License"

--- a/src/cljc/re_mdl/components/badge.cljc
+++ b/src/cljc/re_mdl/components/badge.cljc
@@ -1,4 +1,6 @@
-(ns re-mdl.components.badge)
+(ns re-mdl.components.badge
+  (#?(:clj :require
+      :cljs :require-macros) [re-mdl.macros :refer [build-class]]))
 
 (defn badge
   [& {:keys [el child badge-label no-background? overlap? icon?
@@ -10,11 +12,12 @@
    [el
     (merge
      (cond-> {:id id
-              :class (str "mdl-badge"
-                          (and class          (str  " " class))
-                          (and no-background? " mdl-badge--no-background")
-                          (and overlap?       " mdl-badge--overlap")
-                          (and icon?          " material-icons"))}
+              :class
+              (build-class "mdl-badge"
+                           class          (str  " " class)
+                           no-background? " mdl-badge--no-background"
+                           overlap?       " mdl-badge--overlap"
+                           icon?          " material-icons")}
        badge-label (assoc :data-badge badge-label))
      attr)
     child]

--- a/src/cljc/re_mdl/components/badge.cljc
+++ b/src/cljc/re_mdl/components/badge.cljc
@@ -13,7 +13,7 @@
               :class (str "mdl-badge"
                           (and class          (str  " " class))
                           (and no-background? " mdl-badge--no-background")
-                          (and overlap?)      " mdl-badge--overlap"
+                          (and overlap?       " mdl-badge--overlap")
                           (and icon?          " material-icons"))}
        badge-label (assoc :data-badge badge-label))
      attr)

--- a/src/cljc/re_mdl/components/badge.cljc
+++ b/src/cljc/re_mdl/components/badge.cljc
@@ -10,11 +10,11 @@
    [el
     (merge
      (cond-> {:id id
-              :class (cond-> "mdl-badge"
-                       class          (str (str " " class))
-                       no-background? (str " mdl-badge--no-background")
-                       overlap?       (str " mdl-badge--overlap")
-                       icon?          (str " material-icons"))}
+              :class (str "mdl-badge"
+                          (and class          (str  " " class))
+                          (and no-background? " mdl-badge--no-background")
+                          (and overlap?)      " mdl-badge--overlap"
+                          (and icon?          " material-icons"))}
        badge-label (assoc :data-badge badge-label))
      attr)
     child]

--- a/src/cljc/re_mdl/components/button.cljc
+++ b/src/cljc/re_mdl/components/button.cljc
@@ -15,16 +15,16 @@
     (merge
      (cond-> {:on-click on-click
               :id       id
-              :class    (cond-> "mdl-button mdl-js-button"
-                          class          (str (str " " class))
-                          raised?        (str " mdl-button--raised")
-                          fab?           (str " mdl-button--fab")
-                          mini-fab?      (str " mdl-button--fab mdl-button--mini-fab")
-                          icon?          (str " mdl-button--icon")
-                          colored?       (str " mdl-button--colored")
-                          primary?       (str " mdl-button--primary")
-                          accent?        (str " mdl-button--accent")
-                          ripple-effect? (str " mdl-js-ripple-effect"))}
+              :class    (str "mdl-button mdl-js-button"
+                             (and class          (str " " class))
+                             (and raised?        " mdl-button--raised")
+                             (and fab?           " mdl-button--fab")
+                             (and mini-fab?      " mdl-button--fab mdl-button--mini-fab")
+                             (and icon?          " mdl-button--icon")
+                             (and colored?       " mdl-button--colored")
+                             (and primary?       " mdl-button--primary")
+                             (and accent?        " mdl-button--accent")
+                             (and ripple-effect? " mdl-js-ripple-effect"))}
        disabled? (assoc :disabled true)
        for       (assoc :for for))
      attr)

--- a/src/cljc/re_mdl/components/button.cljc
+++ b/src/cljc/re_mdl/components/button.cljc
@@ -1,5 +1,7 @@
 (ns re-mdl.components.button
-  (:require [re-mdl.util :refer [wrap-mdl]]))
+  (:require [re-mdl.util :refer [wrap-mdl]]
+            #?(:clj [re-mdl.macros :refer [build-class]]))
+  #?(:cljs (:require-macros [re-mdl.macros :refer [build-class]])))
 
 (defn button*
   [& {:keys [el child on-click
@@ -15,16 +17,16 @@
     (merge
      (cond-> {:on-click on-click
               :id       id
-              :class    (str "mdl-button mdl-js-button"
-                             (and class          (str " " class))
-                             (and raised?        " mdl-button--raised")
-                             (and fab?           " mdl-button--fab")
-                             (and mini-fab?      " mdl-button--fab mdl-button--mini-fab")
-                             (and icon?          " mdl-button--icon")
-                             (and colored?       " mdl-button--colored")
-                             (and primary?       " mdl-button--primary")
-                             (and accent?        " mdl-button--accent")
-                             (and ripple-effect? " mdl-js-ripple-effect"))}
+              :class    (build-class "mdl-button mdl-js-button"
+                                     class          (str " " class)
+                                     raised?        " mdl-button--raised"
+                                     fab?           " mdl-button--fab"
+                                     mini-fab?      " mdl-button--fab mdl-button--mini-fab"
+                                     icon?          " mdl-button--icon"
+                                     colored?       " mdl-button--colored"
+                                     primary?       " mdl-button--primary"
+                                     accent?        " mdl-button--accent"
+                                     ripple-effect? " mdl-js-ripple-effect")}
        disabled? (assoc :disabled true)
        for       (assoc :for for))
      attr)

--- a/src/cljc/re_mdl/components/card.cljc
+++ b/src/cljc/re_mdl/components/card.cljc
@@ -1,4 +1,6 @@
-(ns re-mdl.components.card)
+(ns re-mdl.components.card
+  (#?(:clj :require
+      :cljs :require-macros) [re-mdl.macros :refer [build-class]]))
 
 (defn subtitle [& {:keys [child el
                           children
@@ -8,8 +10,8 @@
    [el
     (merge
      {:id    id
-      :class (cond-> "mdl-card__subtitle-text"
-               class (str " " class))}
+      :class (build-class "mdl-card__subtitle-text"
+                          class (str " " class))}
      attr)
     child]
    children))
@@ -25,10 +27,10 @@
    [el
     (merge
      {:id    id
-      :class (cond-> "mdl-card__title"
-               class   (str " " class)
-               border? (str " mdl-card--border")
-               expand? (str " mdl-card--expand"))}
+      :class (build-class "mdl-card__title"
+                          class   (str " " class)
+                          border? " mdl-card--border"
+                          expand? " mdl-card--expand")}
      attr)
     (when child
       [header {:class "mdl-card__title-text"}
@@ -44,9 +46,9 @@
    [el
     (merge
      {:id id
-      :class (cond-> "mdl-card__media"
-               class (str " " class)
-               border? (str " mdl-card--border"))}
+      :class (build-class "mdl-card__media"
+                          class (str " " class)
+                          border? " mdl-card--border")}
      attr)]
    children))
 
@@ -59,9 +61,9 @@
    [el
     (merge
      {:id id
-      :class (cond-> "mdl-card__supporting-text"
-               class (str " " class)
-               border? (str " mdl-card--border"))}
+      :class (build-class "mdl-card__supporting-text"
+                          class (str " " class)
+                          border? " mdl-card--border")}
      attr)]
    children))
 
@@ -74,9 +76,9 @@
    [el
     (merge
      {:id id
-      :class (cond-> "mdl-card__actions"
-               class   (str " " class)
-               border? (str " mdl-card--border"))}
+      :class (build-class "mdl-card__actions"
+                          class   (str " " class)
+                          border? " mdl-card--border")}
      attr)]
    children))
 
@@ -89,8 +91,8 @@
    [el
     (merge
      {:id    id
-      :class (cond-> "mdl-card__menu"
-               class (str " " class))}
+      :class (build-class "mdl-card__menu"
+                          class (str " " class))}
      attr)]
    children))
 
@@ -109,8 +111,8 @@
    [el
     (merge
      {:id id
-      :class (cond-> "mdl-card"
-               class  (str " " class)
-               shadow (str " mdl-shadow--" shadow "dp"))}
+      :class (build-class "mdl-card"
+                          class  (str " " class)
+                          shadow (str " mdl-shadow--" shadow "dp"))}
      attr)]
    children))

--- a/src/cljc/re_mdl/components/chip.cljc
+++ b/src/cljc/re_mdl/components/chip.cljc
@@ -1,4 +1,6 @@
-(ns re-mdl.components.chip)
+(ns re-mdl.components.chip
+  (#?(:clj :require
+      :cljs :require-macros) [re-mdl.macros :refer [build-class]]))
 
 (defn contact
   "Implementation of the MDL chip inner contact component."
@@ -11,8 +13,8 @@
    [el
     (merge
      {:id    id
-      :class (cond-> "mdl-chip__contact"
-               class (str " " class))}
+      :class (build-class "mdl-chip__contact"
+                          class (str " " class))}
      attr)
     child]
    children))
@@ -28,8 +30,8 @@
    [el
     (merge
      {:id    id
-      :class (cond-> "mdl-chip__text"
-               class (str " " class))}
+      :class (build-class "mdl-chip__text"
+                          class (str " " class))}
      attr)
     child]
    children))
@@ -47,8 +49,8 @@
     (merge
      (cond-> {:id       id
               :on-click on-click
-              :class    (cond-> "mdl-chip__action"
-                          class (str " " class))}
+              :class    (build-class "mdl-chip__action"
+                                     class (str " " class))}
        type (assoc :type type))
      attr)
     child]
@@ -66,10 +68,10 @@
     (merge
      (cond-> {:id       id
               :on-click on-click
-              :class    (cond-> "mdl-chip"
-                          class      (str " " class)
-                          contact?   (str " mdl-chip--contact")
-                          deletable? (str " mdl-chip--deletable"))}
+              :class    (build-class "mdl-chip"
+                                     class      (str " " class)
+                                     contact?   " mdl-chip--contact"
+                                     deletable? " mdl-chip--deletable")}
        button? (assoc :type button?))
      attr)]
    children))

--- a/src/cljc/re_mdl/components/dialog.cljc
+++ b/src/cljc/re_mdl/components/dialog.cljc
@@ -1,5 +1,7 @@
 (ns re-mdl.components.dialog
-  (:require [re-mdl.util :refer [wrap-dialog-polyfill]]))
+  (:require [re-mdl.util :refer [wrap-dialog-polyfill]]
+            #?(:clj [re-mdl.macros :refer [build-class]]))
+  #?(:cljs (:require-macros [re-mdl.macros :refer [build-class]])))
 
 (defn title [& {:keys [child el
                        children
@@ -10,8 +12,8 @@
    [el
     (merge
      {:id    id
-      :class (cond-> "mdl-dialog__title"
-               class (str " " class))}
+      :class (build-class "mdl-dialog__title"
+                          class (str " " class))}
      attr)
     child]
    children))
@@ -25,8 +27,8 @@
    [el
     (merge
      {:id    id
-      :class (cond-> "mdl-dialog__content"
-               class (str " " class))}
+      :class (build-class "mdl-dialog__content"
+                          class (str " " class))}
      attr)]
    children))
 
@@ -40,9 +42,9 @@
    [el
     (merge
      {:id    id
-      :class (cond-> "mdl-dialog__actions"
-               class       (str " " class)
-               full-width? (str " mdl-dialog__actions--full-width"))}
+      :class (build-class "mdl-dialog__actions"
+                          class       (str " " class)
+                          full-width? " mdl-dialog__actions--full-width")}
      attr)]
    children))
 
@@ -53,8 +55,8 @@
    [:dialog
     (merge
      {:id    id
-      :class (cond-> "mdl-dialog"
-               class (str " " class))}
+      :class (build-class "mdl-dialog"
+                          class (str " " class))}
      attr)]
    children))
 

--- a/src/cljc/re_mdl/components/grid.cljc
+++ b/src/cljc/re_mdl/components/grid.cljc
@@ -1,4 +1,6 @@
-(ns re-mdl.components.grid)
+(ns re-mdl.components.grid
+  (#?(:clj :require
+      :cljs :require-macros) [re-mdl.macros :refer [build-class]]))
 
 (defn grid [& {:keys [no-spacing?
                       children
@@ -8,9 +10,9 @@
    [:div
     (merge
      {:id    id
-      :class (cond-> "mdl-grid"
-               class       (str " " class)
-               no-spacing? (str " mdl-grid--no-spacing"))}
+      :class (build-class "mdl-grid"
+                          class       (str " " class)
+                          no-spacing? " mdl-grid--no-spacing")}
      attr)]
    children))
 
@@ -33,13 +35,13 @@
      {:id    id
       :class
       (apply str
-             "mdl-cell"
-             (and class    (str " " class))
-             (and stretch? (str " mdl-cell--stretch"))
-             (and align    (str " " (align-mdl-class align)))
-             (and offset   (str " mdl-cell--" offset "-offset"))
-             (and order    (str " mdl-cell--" order "-order"))
-             (and col      (str " mdl-cell--" col "-col"))
+             (build-class "mdl-cell"
+                          class    (str " " class)
+                          stretch? (str " mdl-cell--stretch")
+                          align    (str " " (align-mdl-class align))
+                          offset   (str " mdl-cell--" offset "-offset")
+                          order    (str " mdl-cell--" order "-order")
+                          col      (str " mdl-cell--" col "-col"))
 
              (for [[view-type arg-map] (select-keys args [:desktop :tablet :phone])
                    [arg v] arg-map

--- a/src/cljc/re_mdl/components/grid.cljc
+++ b/src/cljc/re_mdl/components/grid.cljc
@@ -31,27 +31,27 @@
    [:div
     (merge
      {:id    id
-      :class (cond-> "mdl-cell"
-               class    (str " " class)
-               stretch? (str " mdl-cell--stretch")
-               align    (str " " (align-mdl-class align))
-               offset   (str " mdl-cell--" offset "-offset")
-               order    (str " mdl-cell--" order "-order")
-               col      (str " mdl-cell--" col "-col")
-               desktop  (cond->
-                            (:col desktop)    (str " mdl-cell--" (:col desktop) "-col-desktop")
-                            (:offset desktop) (str " mdl-cell--" (:offset desktop) "-offset-desktop")
-                            (:order desktop)  (str " mdl-cell--" (:order desktop) "-order-desktop")
-                            (:hide? desktop)  (str " mdl-cell--hide-desktop"))
-               tablet   (cond->
-                            (:col tablet)    (str " mdl-cell--" (:col tablet) "-col-tablet")
-                            (:offset tablet) (str " mdl-cell--" (:offset tablet) "-offset-tablet")
-                            (:order tablet)  (str " mdl-cell--" (:order tablet) "-order-tablet")
-                            (:hide? tablet)  (str " mdl-cell--hide-tablet"))
-               phone    (cond->
-                            (:col phone)    (str " mdl-cell--" (:col phone) "-col-phone")
-                            (:offset phone) (str " mdl-cell--" (:offset phone) "-offset-phone")
-                            (:order phone)  (str " mdl-cell--" (:order phone) "-order-phone")
-                            (:hide? phone)  (str " mdl-cell--hide-phone")))}
+      :class
+      (apply str
+             "mdl-cell"
+             (and class    (str " " class))
+             (and stretch? (str " mdl-cell--stretch"))
+             (and align    (str " " (align-mdl-class align)))
+             (and offset   (str " mdl-cell--" offset "-offset"))
+             (and order    (str " mdl-cell--" order "-order"))
+             (and col      (str " mdl-cell--" col "-col"))
+
+             (for [[view-type arg-map] (select-keys args [:desktop :tablet :phone])
+                   [arg v] arg-map
+                   :let [view-str (name view-type)]]
+               (case arg
+                 :col    (str " mdl-cell--" v "-col-" view-str)
+                 :offset (str " mdl-cell--" v "-offset-" view-str)
+                 :order  (str " mdl-cell--" v "-order-" view-str)
+                 :hide?  (str " mdl-cell--hide-" view-str)
+                 (throw (ex-info "Invalid arg for cell view"
+                                 {:type ::invalid-arg
+                                  :arg arg
+                                  :view-type view-type})))))}
      attr)]
    children))

--- a/src/cljc/re_mdl/components/layout.cljc
+++ b/src/cljc/re_mdl/components/layout.cljc
@@ -1,5 +1,7 @@
 (ns re-mdl.components.layout
-  (:require [re-mdl.util :refer [wrap-mdl]]))
+  (:require [re-mdl.util :refer [wrap-mdl]]
+            #?(:clj [re-mdl.macros :refer [build-class]]))
+  #?(:cljs (:require-macros [re-mdl.macros :refer [build-class]])))
 
 (defn layout* [& {:keys [fixed-drawer? fixed-header? fixed-tabs?
                          no-drawer-button? no-desktop-drawer-button?
@@ -11,13 +13,13 @@
     [:div
      (merge
       {:id    id
-       :class (cond-> "mdl-layout mdl-js-layout"
-                class                     (str " " class)
-                fixed-drawer?             (str " mdl-layout--fixed-drawer")
-                fixed-header?             (str " mdl-layout--fixed-header")
-                fixed-tabs?               (str " mdl-layout--fixed-tabs")
-                no-drawer-button?         (str " mdl-layout--no-drawer-button")
-                no-desktop-drawer-button? (str " mdl-layout--no-desktop-drawer-button"))}
+       :class (build-class "mdl-layout mdl-js-layout"
+                           class                     (str " " class)
+                           fixed-drawer?             " mdl-layout--fixed-drawer"
+                           fixed-header?             " mdl-layout--fixed-header"
+                           fixed-tabs?               " mdl-layout--fixed-tabs"
+                           no-drawer-button?         " mdl-layout--no-drawer-button"
+                           no-desktop-drawer-button? " mdl-layout--no-desktop-drawer-button")}
       attr)]
     children)])
 
@@ -32,10 +34,10 @@
    [:span
     (merge
      {:id    id
-      :class (cond-> "mdl-layout-title"
-               class              (str " " class)
-               large-screen-only? (str " mdl-layout--large-screen-only")
-               small-screen-only? (str " mdl-layout--small-screen-only"))}
+      :class (build-class "mdl-layout-title"
+                          class              (str " " class)
+                          large-screen-only? " mdl-layout--large-screen-only"
+                          small-screen-only? " mdl-layout--small-screen-only")}
      attr)
     label]
    children))
@@ -48,10 +50,10 @@
    [:div
     (merge
      {:id id
-      :class (cond-> "mdl-layout-spacer"
-               class (str " " class)
-               large-screen-only? (str " mdl-layout--large-screen-only")
-               small-screen-only? (str " mdl-layout--small-screen-only"))}
+      :class (build-class "mdl-layout-spacer"
+                          class (str " " class)
+                          large-screen-only? " mdl-layout--large-screen-only"
+                          small-screen-only? " mdl-layout--small-screen-only")}
      attr)]
    children))
 
@@ -65,28 +67,28 @@
    [:header
     (merge
      {:id id
-      :class (cond-> "mdl-layout__header"
-               class (str " " class)
-               large-screen-only?  (str " mdl-layout--large-screen-only")
-               small-screen-only?  (str " mdl-layout--small-screen-only")
-               waterfall?          (str " mdl-layout__header--waterfall")
-               waterfall-hide-top? (str " mdl-layout__header--waterfall-hide-top")
-               transparent?        (str " mdl-layout__header--transparent")
-               seamed?             (str " mdl-layout__header--seamed")
-               scroll?             (str " mdl-layout__header--scroll"))}
+      :class (build-class "mdl-layout__header"
+                          class (str " " class)
+                          large-screen-only?  " mdl-layout--large-screen-only"
+                          small-screen-only?  " mdl-layout--small-screen-only"
+                          waterfall?          " mdl-layout__header--waterfall"
+                          waterfall-hide-top? " mdl-layout__header--waterfall-hide-top"
+                          transparent?        " mdl-layout__header--transparent"
+                          seamed?             " mdl-layout__header--seamed"
+                          scroll?             " mdl-layout__header--scroll")}
      attr)]
    children))
 
 (defn icon [& {:keys [large-screen-only? small-screen-only?
                       id class attr]
-                :as   args}]
+               :as   args}]
   [:img
    (merge
     {:id    id
-     :class (cond-> "mdl-layout-icon"
-              class (str " " class)
-              large-screen-only? (str " mdl-layout--large-screen-only")
-              small-screen-only? (str " mdl-layout--small-screen-only"))}
+     :class (build-class "mdl-layout-icon"
+                         class (str " " class)
+                         large-screen-only? " mdl-layout--large-screen-only"
+                         small-screen-only? " mdl-layout--small-screen-only")}
     attr)])
 
 (defn header-row [& {:keys [large-screen-only? small-screen-only?
@@ -97,10 +99,10 @@
    [:div
     (merge
      {:id    id
-      :class (cond-> "mdl-layout__header-row"
-               class (str " " class)
-               large-screen-only? (str " mdl-layout--large-screen-only")
-               small-screen-only? (str " mdl-layout--small-screen-only"))}
+      :class (build-class "mdl-layout__header-row"
+                          class (str " " class)
+                          large-screen-only? " mdl-layout--large-screen-only"
+                          small-screen-only? " mdl-layout--small-screen-only")}
      attr)]
    children))
 
@@ -112,10 +114,10 @@
    [:div
     (merge
      {:id    id
-      :class (cond-> "mdl-layout__drawer"
-               class (str " " class)
-               large-screen-only? (str " mdl-layout--large-screen-only")
-               small-screen-only? (str " mdl-layout--small-screen-only"))}
+      :class (build-class "mdl-layout__drawer"
+                          class (str " " class)
+                          large-screen-only? " mdl-layout--large-screen-only"
+                          small-screen-only? " mdl-layout--small-screen-only")}
      attr)]
    children))
 
@@ -127,10 +129,10 @@
    [:main
     (merge
      {:id id
-      :class (cond-> "mdl-layout__content"
-               class (str " " class)
-               large-screen-only? (str " mdl-layout--large-screen-only")
-               small-screen-only? (str " mdl-layout--small-screen-only"))}
+      :class (build-class "mdl-layout__content"
+                          class (str " " class)
+                          large-screen-only? " mdl-layout--large-screen-only"
+                          small-screen-only? " mdl-layout--small-screen-only")}
      attr)]
    children))
 
@@ -141,26 +143,26 @@
   (into [:nav
          (merge
           {:id id
-           :class (cond-> "mdl-navigation"
-                    class (str " " class)
-                    large-screen-only? (str " mdl-layout--large-screen-only")
-                    small-screen-only? (str " mdl-layout--small-screen-only"))}
+           :class (build-class "mdl-navigation"
+                               class (str " " class)
+                               large-screen-only? " mdl-layout--large-screen-only"
+                               small-screen-only? " mdl-layout--small-screen-only")}
           attr)]
         children))
 
 (defn nav-link [& {:keys [large-screen-only? small-screen-only?
                           href content on-click
                           id class attr]
-              :as   args}]
+                   :as   args}]
   [:a
    (merge
     (cond->
         {:id id
          :href href
-         :class (cond-> "mdl-navigation__link"
-                  class (str " " class)
-                  large-screen-only? (str " mdl-layout--large-screen-only")
-                  small-screen-only? (str " mdl-layout--small-screen-only"))}
+         :class (build-class "mdl-navigation__link"
+                             class (str " " class)
+                             large-screen-only? " mdl-layout--large-screen-only"
+                             small-screen-only? " mdl-layout--small-screen-only")}
       on-click (assoc :on-click on-click))
     attr)
    content])
@@ -175,12 +177,12 @@
   (into [:div
          (merge
           {:id id
-           :class (cond-> "mdl-layout__tab-bar"
-                    class              (str " " class)
-                    ripple-effect?     (str " mdl-js-ripple-effect")
-                    large-screen-only? (str " mdl-layout--large-screen-only")
-                    small-screen-only? (str " mdl-layout--small-screen-only")
-                    tab-manual-switch? (str " mdl-layout__tab-manual-switch"))}
+           :class (build-class "mdl-layout__tab-bar"
+                               class              (str " " class)
+                               ripple-effect?     " mdl-js-ripple-effect"
+                               large-screen-only? " mdl-layout--large-screen-only"
+                               small-screen-only? " mdl-layout--small-screen-only"
+                               tab-manual-switch? " mdl-layout__tab-manual-switch")}
           attr)] children))
 
 (defn layout-tab [& {:keys [large-screen-only? small-screen-only? is-active?
@@ -191,11 +193,11 @@
    (merge
     {:id id
      :href href
-     :class (cond-> "mdl-layout__tab"
-              class (str " " class)
-              large-screen-only? (str " mdl-layout--large-screen-only")
-              small-screen-only? (str " mdl-layout--small-screen-only")
-              is-active? (str " is-active"))}
+     :class (build-class "mdl-layout__tab"
+                         class (str " " class)
+                         large-screen-only? " mdl-layout--large-screen-only"
+                         small-screen-only? " mdl-layout--small-screen-only"
+                         is-active? " is-active")}
     attr)
    content])
 
@@ -208,12 +210,12 @@
    [:section
     (merge
      {:id    id
-      :class (cond-> "mdl-layout__tab-panel"
-               class              (str " " class)
-               large-screen-only? (str " mdl-layout--large-screen-only")
-               small-screen-only? (str " mdl-layout--small-screen-only")
-               is-active?         (str " is-active")
-               ripple-effect?     (str " mdl-js-ripple-effect"))}
+      :class (build-class "mdl-layout__tab-panel"
+                          class              (str " " class)
+                          large-screen-only? " mdl-layout--large-screen-only"
+                          small-screen-only? " mdl-layout--small-screen-only"
+                          is-active?         " is-active"
+                          ripple-effect?     " mdl-js-ripple-effect")}
      attr)]
    children))
 
@@ -226,8 +228,8 @@
    [:div
     (merge
      {:id    id
-      :class (cond-> "mdl-tabs__tab-bar"
-               class (str " " class))}
+      :class (build-class "mdl-tabs__tab-bar"
+                          class (str " " class))}
      attr)]
    children))
 
@@ -239,9 +241,9 @@
    [:div
     (merge
      {:id    id
-      :class (cond-> "mdl-tabs mdl-js-tabs"
-               class          (str " " class)
-               ripple-effect? (str " mdl-js-ripple-effect"))}
+      :class (build-class "mdl-tabs mdl-js-tabs"
+                          class          (str " " class)
+                          ripple-effect? " mdl-js-ripple-effect")}
      attr)]
    children))
 
@@ -257,9 +259,9 @@
     (merge
      {:id    id
       :href  href
-      :class (cond-> "mdl-tabs__tab"
-               class          (str " " class)
-               is-active?     (str " is-active"))}
+      :class (build-class "mdl-tabs__tab"
+                          class          (str " " class)
+                          is-active?     " is-active")}
      attr)
     child]
    children))
@@ -273,9 +275,9 @@
    [el
     (merge
      {:id    id
-      :class (cond-> "mdl-tabs__panel"
-               class      (str " " class)
-               is-active? (str " is-active"))}
+      :class (build-class "mdl-tabs__panel"
+                          class      (str " " class)
+                          is-active? " is-active")}
      attr)]
    children))
 
@@ -290,8 +292,8 @@
    [:button
     (merge
      {:id    id
-      :class (cond-> "mdl-mega-footer__social-btn"
-               class (str " " class))}
+      :class (build-class "mdl-mega-footer__social-btn"
+                          class (str " " class))}
      attr)
     child]
    children))
@@ -302,8 +304,8 @@
   (into [:ul
          (merge
           {:id id
-           :class (cond-> "mdl-mega-footer__link-list"
-                    class (str " " class))}
+           :class (build-class "mdl-mega-footer__link-list"
+                               class (str " " class))}
           attr)]
         (for [child children]
           ^{:key child} [:li child])))
@@ -315,8 +317,8 @@
   [:div
    (merge
     {:id id
-     :class (cond-> "mdl-mega-footer__drop-down-section"
-              class (str " " class))}
+     :class (build-class "mdl-mega-footer__drop-down-section"
+                         class (str " " class))}
     attr)
    [:h1.mdl-mega-footer__heading
     heading]
@@ -331,8 +333,8 @@
    [:footer
     (merge
      {:id    id
-      :class (cond-> "mdl-mega-footer"
-               class (str " " class))}
+      :class (build-class "mdl-mega-footer"
+                          class (str " " class))}
      attr)
     (when top
       (into [:div.mdl-mega-footer__top-section] top))
@@ -355,8 +357,8 @@
    [:button
     (merge
      {:id    id
-      :class (cond-> "mdl-mega-footer__social-btn"
-               class (str " " class))}
+      :class (build-class "mdl-mega-footer__social-btn"
+                          class (str " " class))}
      attr)
     child]
    children))
@@ -368,8 +370,8 @@
    [:ul
     (merge
      {:id id
-      :class (cond-> "mdl-mini-footer__link-list"
-               class (str " " class))}
+      :class (build-class "mdl-mini-footer__link-list"
+                          class (str " " class))}
      attr)]
    (for [child children]
      ^{:key child} [:li child])))
@@ -382,8 +384,8 @@
    [:footer
     (merge
      {:id id
-      :class (cond-> "mdl-mini-footer"
-               class (str " " class))}
+      :class (build-class "mdl-mini-footer"
+                          class (str " " class))}
      attr)
     (when left
       (into [:div.mdl-mini-footer__left-section

--- a/src/cljc/re_mdl/components/list.cljc
+++ b/src/cljc/re_mdl/components/list.cljc
@@ -1,4 +1,6 @@
-(ns re-mdl.components.list)
+(ns re-mdl.components.list
+  (#?(:clj :require
+      :cljs :require-macros) [re-mdl.macros :refer [build-class]]))
 
 (defn item-primary-content [& {:keys [el icon avatar child
                                       children
@@ -10,8 +12,8 @@
    [el
     (merge
      {:id    id
-      :class (cond-> "mdl-list__item-primary-content"
-               class (str " " class))}
+      :class (build-class "mdl-list__item-primary-content"
+                          class (str " " class))}
      attr)
     (when-let [icon-name (or icon avatar)]
       [:i.material-icons
@@ -31,8 +33,8 @@
    [el
     (merge
      {:id    id
-      :class (cond-> "mdl-list__item-secondary-content"
-               class (str " " class))}
+      :class (build-class "mdl-list__item-secondary-content"
+                          class (str " " class))}
      attr)
     child]
    children))
@@ -49,8 +51,8 @@
    [el
     (merge
      (cond-> {:id    id
-              :class (cond-> "mdl-list__item-secondary-action"
-                       class (str " " class))}
+              :class (build-class "mdl-list__item-secondary-action"
+                                  class (str " " class))}
        href (assoc :href href))
      attr)
     child]
@@ -65,8 +67,8 @@
    [el
     (merge
      {:id    id
-      :class (cond-> "mdl-list__item-secondary-info"
-               class (str " " class))}
+      :class (build-class "mdl-list__item-secondary-info"
+                          class (str " " class))}
      attr)
     child]
    children))
@@ -80,8 +82,8 @@
    [el
     (merge
      {:id    id
-      :class (cond-> "mdl-list__item-text-body"
-               class (str " " class))}
+      :class (build-class "mdl-list__item-text-body"
+                          class (str " " class))}
      attr)
     child]
    children))
@@ -94,8 +96,8 @@
   (into
    [el
     (merge {:id    id
-            :class (cond-> "mdl-list__item-sub-title"
-                     class (str " " class))}
+            :class (build-class "mdl-list__item-sub-title"
+                                class (str " " class))}
            attr)
     child]
    children))
@@ -113,12 +115,12 @@
    [:li
     (merge
      {:id    id
-      :class (cond-> (str "mdl-list__item mdl-list__item"
-                          (case item-type
-                            :two-line   "--two-line"
-                            :three-line "--three-line"
-                            nil))
-               class (str " " class))}
+      :class (build-class (str "mdl-list__item mdl-list__item"
+                               (case item-type
+                                 :two-line   "--two-line"
+                                 :three-line "--three-line"
+                                 nil))
+                          class (str " " class))}
      attr)]
    children))
 

--- a/src/cljc/re_mdl/components/loading.cljc
+++ b/src/cljc/re_mdl/components/loading.cljc
@@ -1,6 +1,8 @@
 (ns re-mdl.components.loading
+  #?(:cljs (:require-macros [re-mdl.macros :refer [build-class]]))
   (:require
    #?(:cljs [reagent.core :as r])
+   #?(:clj [re-mdl.macros :refer [build-class]])
    [re-mdl.util :refer [wrap-mdl
                         mdl-init!
                         mdl-get-value
@@ -17,11 +19,11 @@
      [:div
       (merge
        {:id    id
-        :class (cond-> "mdl-progress mdl-js-progress"
-                 class (str " " class)
-                 #?(:cljs indeterminate?
-                    :clj  true) ;; always indeterminate for clj
-                 (str " mdl-progress--indeterminate"))}
+        :class (build-class "mdl-progress mdl-js-progress"
+                            class (str " " class)
+                            #?(:cljs indeterminate?
+                               :clj  true) ;; always indeterminate for clj
+                            " mdl-progress--indeterminate")}
        attr)]
      children)))
 
@@ -56,10 +58,10 @@
    [el
     (merge
      {:id id
-      :class (cond-> "mdl-spinner mdl-js-spinner"
-               class         (str " " class)
-               is-active?    (str " is-active")
-               single-color? (str " mdl-spinner--single-color"))}
+      :class (build-class "mdl-spinner mdl-js-spinner"
+                          class         (str " " class)
+                          is-active?    " is-active"
+                          single-color? " mdl-spinner--single-color")}
      attr)]
    children))
 

--- a/src/cljc/re_mdl/components/menu.cljc
+++ b/src/cljc/re_mdl/components/menu.cljc
@@ -1,5 +1,7 @@
 (ns re-mdl.components.menu
-  (:require [re-mdl.util :refer [wrap-mdl]]))
+  (:require [re-mdl.util :refer [wrap-mdl]]
+            #?(:clj [re-mdl.macros :refer [build-class]]))
+  #?(:cljs (:require-macros [re-mdl.macros :refer [build-class]])))
 
 (defn item [& {:keys [child disabled? on-click
                       full-bleed-divider?
@@ -10,10 +12,10 @@
    [:li
     (merge
      (cond-> {:id id
-              :class (cond-> "mdl-menu__item"
+              :class (build-class "mdl-menu__item"
                        class (str " " class)
                        full-bleed-divider?
-                       (str " mdl-menu__item--full-bleed-divider"))}
+                       " mdl-menu__item--full-bleed-divider")}
        disabled? (assoc :disabled true)
        on-click  (assoc :on-click on-click))
      attr)
@@ -30,12 +32,12 @@
     (merge
      {:id id
       :for for
-      :class (cond-> "mdl-menu mdl-js-menu"
+      :class (build-class "mdl-menu mdl-js-menu"
                class          (str " " class)
-               ripple-effect? (str " mdl-js-ripple-effect")
-               top-left?      (str " mdl-menu--top-left")
-               top-right?     (str " mdl-menu--top-right")
-               bottom-right?  (str " mdl-menu--bottom-right"))}
+               ripple-effect? " mdl-js-ripple-effect"
+               top-left?      " mdl-menu--top-left"
+               top-right?     " mdl-menu--top-right"
+               bottom-right?  " mdl-menu--bottom-right")}
      attr)]
    children))
 

--- a/src/cljc/re_mdl/components/slider.cljc
+++ b/src/cljc/re_mdl/components/slider.cljc
@@ -1,8 +1,10 @@
 (ns re-mdl.components.slider
   (:require #?(:cljs [reagent.core :as r])
+            #?(:clj [re-mdl.macros :refer [build-class]])
             [re-mdl.util :refer [mdl-init-mount
                                  mdl-get-value
-                                 mdl-get-props]]))
+                                 mdl-get-props]])
+  #?(:cljs (:require-macros [re-mdl.macros :refer [build-class]])))
 
 (defn slider* [& {:keys [min max step model disabled?
                          handler-fn
@@ -22,8 +24,8 @@
             :min   (mdl-get-value min)
             :max   (mdl-get-value max)
             :step  (mdl-get-value step)
-            :class (cond-> "mdl-slider mdl-js-slider"
-                     class (str " " class))
+            :class (build-class "mdl-slider mdl-js-slider"
+                                class (str " " class))
             #?@(:cljs
                 [:on-change
                  (fn [e] (handler-fn (.. e -target -value)))

--- a/src/cljc/re_mdl/components/table.cljc
+++ b/src/cljc/re_mdl/components/table.cljc
@@ -1,5 +1,7 @@
 (ns re-mdl.components.table
-  (:require [re-mdl.util :refer [wrap-mdl]]))
+  (:require [re-mdl.util :refer [wrap-mdl]]
+            #?(:clj [re-mdl.macros :refer [build-class]]))
+  #?(:cljs (:require-macros [re-mdl.macros :refer [build-class]])))
 
 (def valid-shadows #{2 3 4 6 8 16})
 
@@ -22,22 +24,22 @@
      [:table
       (merge
        {:id    id
-        :class (cond-> "mdl-data-table mdl-js-data-table"
-                 class       (str " " class)
-                 selectable? (str " mdl-data-table--selectable")
-                 shadow      (str " mdl-shadow--" shadow "dp"))}
+        :class (build-class "mdl-data-table mdl-js-data-table"
+                            class       (str " " class)
+                            selectable? " mdl-data-table--selectable"
+                            shadow      (str " mdl-shadow--" shadow "dp"))}
        attr)
       [:thead
        (into [:tr]
              (map-indexed
               (fn [idx [label & {:keys [non-numeric
-                                       ascending
-                                       descending]}]]
+                                        ascending
+                                        descending]}]]
                 [:th
-                 {:class (cond-> ""
-                           non-numeric (str " mdl-data-table__cell--non-numeric")
-                           ascending   (str " mdl-data-table__header--sorted-ascending")
-                           descending  (str " mdl-data-table__header--sorted-descending"))}
+                 {:class (build-class ""
+                                      non-numeric " mdl-data-table__cell--non-numeric"
+                                      ascending   " mdl-data-table__header--sorted-ascending"
+                                      descending  " mdl-data-table__header--sorted-descending")}
                  label])
               headers))]
       (into [:tbody]

--- a/src/cljc/re_mdl/components/textfield.cljc
+++ b/src/cljc/re_mdl/components/textfield.cljc
@@ -1,9 +1,11 @@
 (ns re-mdl.components.textfield
-  (:require #?(:cljs [reagent.core :as r])
+  (:require #?(:cljs [reagent.core :as r]
+               :clj [re-mdl.macros :refer [build-class]])
             [re-mdl.util :refer [mdl-init!
                                  mdl-get-value
                                  mdl-get-props]]
-            [re-mdl.components.button :refer [button]]))
+            [re-mdl.components.button :refer [button]])
+  #?(:cljs (:require-macros [re-mdl.macros :refer [build-class]])))
 
 (defn textfield* [this]
   (let [{:keys [type input-type rows model
@@ -71,10 +73,10 @@
       (into
        [:div
         (merge
-         {:class (cond-> "mdl-textfield mdl-js-textfield"
-                   class           (str " " class)
-                   floating-label? (str " mdl-textfield--floating-label")
-                   expandable?     (str " mdl-textfield--expandable"))}
+         {:class (build-class "mdl-textfield mdl-js-textfield"
+                              class           (str " " class)
+                              floating-label? " mdl-textfield--floating-label"
+                              expandable?     " mdl-textfield--expandable")}
          attr)]
        body))))
 

--- a/src/cljc/re_mdl/components/toggle.cljc
+++ b/src/cljc/re_mdl/components/toggle.cljc
@@ -1,9 +1,11 @@
 (ns re-mdl.components.toggle
-  (:require #?(:cljs [reagent.core :as r])
+  (:require #?(:cljs [reagent.core :as r]
+               :clj [re-mdl.macros :refer [build-class]])
             [re-mdl.util :refer [wrap-mdl
                                  mdl-init-mount
                                  mdl-get-value
-                                 mdl-get-props]]))
+                                 mdl-get-props]])
+  #?(:cljs (:require-macros [re-mdl.macros :refer [build-class]])))
 
 (defn checkbox* [& {:keys [disabled? ripple-effect? model
                            label handler-fn
@@ -18,9 +20,9 @@
      [:label
       (merge
        {:for   id
-        :class (cond-> "mdl-checkbox mdl-js-checkbox"
+        :class (build-class "mdl-checkbox mdl-js-checkbox"
                  class          (str " " class)
-                 ripple-effect? (str " mdl-js-ripple-effect"))}
+                 ripple-effect? " mdl-js-ripple-effect")}
        attr)
       [:input.mdl-checkbox__input
        (merge
@@ -68,9 +70,9 @@
      [:label
       (merge
        {:for id
-        :class (cond-> "mdl-radio mdl-js-radio"
+        :class (build-class "mdl-radio mdl-js-radio"
                  class          (str " " class)
-                 ripple-effect? (str " mdl-js-ripple-effect"))}
+                 ripple-effect? " mdl-js-ripple-effect")}
        attr)
       [:input.mdl-radio__button
        (cond->
@@ -116,7 +118,7 @@
    [:div
     (merge
      {:for   id
-      :class (cond-> "re-mdl-radio"
+      :class (build-class "re-mdl-radio"
                class (str " " class))}
      attr)]
    (or
@@ -146,9 +148,9 @@
      [:label
       (merge
        {:for   id
-        :class (cond-> "mdl-icon-toggle mdl-js-icon-toggle"
+        :class (build-class "mdl-icon-toggle mdl-js-icon-toggle"
                  class          (str " " class)
-                 ripple-effect? (str " mdl-js-ripple-effect"))}
+                 ripple-effect? " mdl-js-ripple-effect")}
        attr)
       [:input.mdl-icon-toggle__input
        (merge
@@ -197,9 +199,9 @@
      [:label
       (merge
        {:for   id
-        :class (cond-> "mdl-switch mdl-js-switch"
+        :class (build-class "mdl-switch mdl-js-switch"
                  class          (str " " class)
-                 ripple-effect? (str " mdl-js-ripple-effect"))}
+                 ripple-effect? " mdl-js-ripple-effect")}
        attr)
       [:input.mdl-switch__input
        (merge

--- a/src/cljc/re_mdl/components/tooltip.cljc
+++ b/src/cljc/re_mdl/components/tooltip.cljc
@@ -1,5 +1,7 @@
 (ns re-mdl.components.tooltip
-  (:require [re-mdl.util :refer [wrap-mdl]]))
+  (:require [re-mdl.util :refer [wrap-mdl]]
+            #?(:clj [re-mdl.macros :refer [build-class]]))
+  #?(:cljs (:require-macros [re-mdl.macros :refer [build-class]])))
 
 (defn tooltip* [& {:keys [el for large? left? right? top? bottom?
                           children
@@ -11,13 +13,13 @@
     (merge
      {:id    id
       :for   for
-      :class (cond-> "mdl-tooltip"
-               class   (str " " class)
-               large?  (str " mdl-tooltip--large")
-               left?   (str " mdl-tooltip--left")
-               right?  (str " mdl-tooltip--right")
-               top?    (str " mdl-tooltip--top")
-               bottom? (str " mdl-tooltip--bottom"))}
+      :class (build-class "mdl-tooltip"
+                          class   (str " " class)
+                          large?  " mdl-tooltip--large"
+                          left?   " mdl-tooltip--left"
+                          right?  " mdl-tooltip--right"
+                          top?    " mdl-tooltip--top"
+                          bottom? " mdl-tooltip--bottom")}
      attr)]
    children))
 

--- a/src/cljc/re_mdl/macros.clj
+++ b/src/cljc/re_mdl/macros.clj
@@ -1,0 +1,7 @@
+(ns re-mdl.macros)
+
+(defmacro build-class [^String base & clauses]
+  (assert (even? (count clauses)) "Please provide an even number of clauses.")
+  `(str ~base
+        ~@(for [[test# build-string#] (partition 2 clauses)]
+            `(and ~test# ~build-string#))))


### PR DESCRIPTION
As mentioned in #19 there is a bug in clj that causes high compilation times for functions that make heavy use of `cond->`. We were using this across the board to build class strings, leading to >1 min load times in JVM clojure.
I made a macro, `re-mdl.macros/build-class` which takes a base string and an arbitrary number of test-expression clauses, and expands to a call to `str` with each clause in an `and` like so:

```clojure
(macroexpand '(build-class "base-class"
                          ?class (str " " class)
                          ?foo " --mdl-foo"))
;; =>
(clojure.core/str
 "base-class"
 (clojure.core/and ?class (str " " class))
 (clojure.core/and ?foo " --mdl-foo"))
```